### PR TITLE
🐼 Add floating Hey Panda button for API failure fallback 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -103,11 +103,6 @@
             android:exported="false"
             android:foregroundServiceType="specialUse" />
 
-        <service android:name=".services.WakeWordService"
-            android:enabled="true"
-            android:exported="false"
-            android:foregroundServiceType="specialUse" />
-
         <service android:name=".services.EnhancedWakeWordService"
             android:enabled="true"
             android:exported="false"
@@ -118,6 +113,11 @@
             android:enabled="true"
             android:exported="false"
             android:foregroundServiceType="microphone" />
+
+        <service
+            android:name=".services.FloatingPandaButtonService"
+            android:enabled="true"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/blurr/app/SettingsActivity.kt
+++ b/app/src/main/java/com/blurr/app/SettingsActivity.kt
@@ -162,7 +162,7 @@ class SettingsActivity : AppCompatActivity() {
 
         wakeWordEngineGroup.setOnCheckedChangeListener { _, checkedId ->
             saveWakeWordEngine(checkedId)
-            val engineName = if (checkedId == R.id.sttEngineRadio) "STT" else "Porcupine"
+            val engineName = "Porcupine"
             if (!isInitialLoad) {
                 Toast.makeText(this, "Wake Word Engine set to $engineName", Toast.LENGTH_SHORT).show()
             }
@@ -226,19 +226,12 @@ class SettingsActivity : AppCompatActivity() {
     }
 
     private suspend fun startWakeWordService() {
-        val usePorcupine = wakeWordEngineGroup.checkedRadioButtonId == R.id.porcupineEngineRadio
-        if (usePorcupine) {
-            // For Porcupine, we'll let the service handle the key fetching
-            // The service will automatically fall back to STT if the key can't be obtained
-            Log.d("SettingsActivity", "Starting Porcupine wake word service - key will be fetched automatically")
-        }
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED) {
             val serviceIntent = Intent(this, EnhancedWakeWordService::class.java).apply {
-                putExtra(EnhancedWakeWordService.EXTRA_USE_PORCUPINE, usePorcupine)
+                putExtra(EnhancedWakeWordService.EXTRA_USE_PORCUPINE, true) // Always use Porcupine
             }
             ContextCompat.startForegroundService(this, serviceIntent)
-            val engineName = if (usePorcupine) "Porcupine" else "STT"
-            Toast.makeText(this, getString(R.string.wake_word_enabled, engineName), Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, getString(R.string.wake_word_enabled, "Porcupine"), Toast.LENGTH_SHORT).show()
             updateUIState()
         } else {
             requestPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
@@ -258,7 +251,7 @@ class SettingsActivity : AppCompatActivity() {
         val savedVisionId = sharedPreferences.getInt(KEY_SELECTED_VISION_MODE, R.id.xmlModeRadio)
         visionModeGroup.check(savedVisionId)
 
-        val savedWakeWordId = sharedPreferences.getInt(KEY_SELECTED_WAKE_WORD_ENGINE, R.id.sttEngineRadio)
+        val savedWakeWordId = sharedPreferences.getInt(KEY_SELECTED_WAKE_WORD_ENGINE, R.id.porcupineEngineRadio) // Assuming default is Porcupine
         wakeWordEngineGroup.check(savedWakeWordId)
     }
 

--- a/app/src/main/java/com/blurr/app/api/PorcupineWakeWordDetector.kt
+++ b/app/src/main/java/com/blurr/app/api/PorcupineWakeWordDetector.kt
@@ -11,15 +11,15 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import com.blurr.app.api.PicovoiceKeyManager
 
 class PorcupineWakeWordDetector(
     private val context: Context,
-    private val onWakeWordDetected: () -> Unit
+    private val onWakeWordDetected: () -> Unit,
+    private val onApiFailure: () -> Unit
 ) {
     private var porcupineManager: PorcupineManager? = null
-    private var sttDetector: WakeWordDetector? = null
     private var isListening = false
-    private var useSTTFallback = false
     private val keyManager = PicovoiceKeyManager(context)
     private var coroutineScope: CoroutineScope? = null
 
@@ -44,12 +44,12 @@ class PorcupineWakeWordDetector(
                     Log.d(TAG, "Successfully obtained Picovoice access key")
                     startPorcupineWithKey(accessKey)
                 } else {
-                    Log.e(TAG, "Failed to obtain Picovoice access key. Falling back to STT-based detection.")
-                    startSTTFallback()
+                    Log.e(TAG, "Failed to obtain Picovoice access key. Triggering API failure callback.")
+                    onApiFailure()
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Error getting access key: ${e.message}")
-                startSTTFallback()
+                onApiFailure()
             }
         }
     }
@@ -66,10 +66,10 @@ class PorcupineWakeWordDetector(
             // Create error callback for debugging
             val errorCallback = PorcupineManagerErrorCallback { error ->
                 Log.e(TAG, "Porcupine error: ${error.message}")
-                // If there's an error, fall back to STT
-                if (isListening && !useSTTFallback) {
-                    Log.d(TAG, "Falling back to STT due to Porcupine error")
-                    startSTTFallback()
+                // If there's an error, trigger API failure callback
+                if (isListening) {
+                    Log.d(TAG, "Porcupine error occurred, triggering API failure callback")
+                    onApiFailure()
                 }
             }
 
@@ -83,13 +83,12 @@ class PorcupineWakeWordDetector(
 
             porcupineManager?.start()
             isListening = true
-            useSTTFallback = false
             Log.d(TAG, "Porcupine wake word detection started successfully.")
         } catch (e: Exception) {
             Log.e(TAG, "Error starting Porcupine: ${e.message}")
-            // Fallback to STT-based detection if Porcupine fails
-            Log.d(TAG, "Falling back to STT-based wake word detection")
-            startSTTFallback()
+            // Trigger API failure callback if Porcupine fails
+            Log.d(TAG, "Porcupine failed to start, triggering API failure callback")
+            onApiFailure()
         }
     }
 
@@ -100,36 +99,17 @@ class PorcupineWakeWordDetector(
         }
 
         try {
-            if (useSTTFallback) {
-                sttDetector?.stop()
-                sttDetector = null
-                Log.d(TAG, "STT fallback wake word detection stopped.")
-            } else {
-                porcupineManager?.stop()
-                porcupineManager?.delete()
-                porcupineManager = null
-                Log.d(TAG, "Porcupine wake word detection stopped.")
-            }
+            porcupineManager?.stop()
+            porcupineManager?.delete()
+            porcupineManager = null
             isListening = false
-            useSTTFallback = false
+            Log.d(TAG, "Porcupine wake word detection stopped.")
             
             // Cancel the coroutine scope
             coroutineScope?.cancel()
             coroutineScope = null
         } catch (e: Exception) {
             Log.e(TAG, "Error stopping wake word detection: ${e.message}")
-        }
-    }
-
-    private fun startSTTFallback() {
-        try {
-            sttDetector = WakeWordDetector(context, onWakeWordDetected)
-            sttDetector?.start()
-            isListening = true
-            useSTTFallback = true
-            Log.d(TAG, "STT fallback wake word detection started.")
-        } catch (e: Exception) {
-            Log.e(TAG, "Error starting STT fallback: ${e.message}")
         }
     }
 } 

--- a/app/src/main/java/com/blurr/app/services/FloatingPandaButtonService.kt
+++ b/app/src/main/java/com/blurr/app/services/FloatingPandaButtonService.kt
@@ -1,0 +1,177 @@
+package com.blurr.app.services
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.graphics.PixelFormat
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.provider.Settings
+import android.util.Log
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.WindowManager
+import android.widget.Button
+import androidx.core.content.ContextCompat
+import com.blurr.app.ConversationalAgentService
+import com.blurr.app.R
+
+class FloatingPandaButtonService : Service() {
+
+    private var windowManager: WindowManager? = null
+    private var floatingButton: View? = null
+    private val handler = Handler(Looper.getMainLooper())
+
+    companion object {
+        private const val TAG = "FloatingPandaButton"
+        var isRunning = false
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        isRunning = true
+        Log.d(TAG, "Floating Panda Button Service created")
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.d(TAG, "Floating Panda Button Service starting...")
+        
+        if (!Settings.canDrawOverlays(this)) {
+            Log.w(TAG, "Cannot show floating button: 'Draw over other apps' permission not granted.")
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        try {
+            showFloatingButton()
+            if (floatingButton == null) {
+                Log.w(TAG, "Failed to show floating button, stopping service")
+                stopSelf()
+                return START_NOT_STICKY
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error showing floating button", e)
+            stopSelf()
+            return START_NOT_STICKY
+        }
+        
+        return START_STICKY
+    }
+
+    private fun showFloatingButton() {
+        if (floatingButton != null) {
+            Log.d(TAG, "Floating button already showing")
+            return
+        }
+
+        windowManager = getSystemService(Context.WINDOW_SERVICE) as WindowManager
+
+        try {
+            // Create the button programmatically
+            floatingButton = createButtonProgrammatically()
+            val button = floatingButton as Button
+
+            // Set up the button click listener
+            button.setOnClickListener {
+                Log.d(TAG, "Floating Panda button clicked!")
+                triggerPandaActivation()
+            }
+
+            // Calculate position near the battery icon (top-right area)
+            val displayMetrics = resources.displayMetrics
+            val screenWidth = displayMetrics.widthPixels
+            val screenHeight = displayMetrics.heightPixels
+            
+            // Position the button in the bottom-right area
+            val buttonWidth = (70 * displayMetrics.density).toInt() // 100dp for smaller size
+            val buttonHeight = (33 * displayMetrics.density).toInt() // 40dp for smaller height
+            val marginFromBottom = (0 * displayMetrics.density).toInt() // 100dp from bottom
+            val marginFromRight = (16 * displayMetrics.density).toInt() // 16dp from right edge
+
+            val windowType = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+            } else {
+                WindowManager.LayoutParams.TYPE_PHONE
+            }
+
+            val params = WindowManager.LayoutParams(
+                buttonWidth,
+                buttonHeight,
+                windowType,
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                        WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN,
+                PixelFormat.TRANSLUCENT
+            ).apply {
+                gravity = Gravity.BOTTOM or Gravity.END
+                x = marginFromRight
+                y = marginFromBottom
+            }
+
+            windowManager?.addView(floatingButton, params)
+            Log.d(TAG, "Floating Panda button added successfully")
+        } catch (e: Exception) {
+            Log.e(TAG, "Error adding floating button", e)
+            floatingButton = null
+        }
+    }
+
+    private fun createButtonProgrammatically(): Button {
+        return Button(this).apply {
+            text = "Hey Panda!"
+            textSize = 12f
+            setTextColor(android.graphics.Color.WHITE)
+            setBackgroundColor(android.graphics.Color.parseColor("#BE63F3"))
+            // setPadding(, 1, 2, 1)
+            isClickable = true
+            isFocusable = true
+            
+            // Add some styling to make it look better
+            elevation = 8f
+            alpha = 0.9f
+        }
+    }
+
+    private fun triggerPandaActivation() {
+        // This is the same action that happens when wake word is detected
+        try {
+            if (!ConversationalAgentService.isRunning) {
+                Log.d(TAG, "Starting ConversationalAgentService from floating button")
+                val serviceIntent = Intent(this, ConversationalAgentService::class.java)
+                ContextCompat.startForegroundService(this, serviceIntent)
+            } else {
+                Log.d(TAG, "ConversationalAgentService is already running")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error starting ConversationalAgentService", e)
+        }
+    }
+
+    private fun hideFloatingButton() {
+        floatingButton?.let { button ->
+            try {
+                if (button.isAttachedToWindow) {
+                    windowManager?.removeView(button)
+                } else {
+                    // Button is not attached, just continue
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error removing floating button", e)
+            }
+        }
+        floatingButton = null
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.d(TAG, "Floating Panda Button Service destroying...")
+        hideFloatingButton()
+        isRunning = false
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+} 

--- a/app/src/main/res/drawable/floating_button_background.xml
+++ b/app/src/main/res/drawable/floating_button_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#BE63F3" />
+    <corners android:radius="24dp" />
+    <stroke
+        android:width="2dp"
+        android:color="#FFFFFF" />
+</shape> 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -166,17 +166,6 @@
                 android:orientation="vertical">
 
                 <RadioButton
-                    android:id="@+id/sttEngineRadio"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:buttonTint="#5880F7"
-                    android:checked="false"
-                    android:paddingStart="8dp"
-                    android:text="@string/stt_engine"
-                    android:textColor="#CECECE"
-                    tools:ignore="RtlSymmetry" />
-
-                <RadioButton
                     android:id="@+id/porcupineEngineRadio"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/floating_panda_button.xml
+++ b/app/src/main/res/layout/floating_panda_button.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Button xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/floatingPandaButton"
+    android:layout_width="120dp"
+    android:layout_height="48dp"
+    android:text="Hey Panda!"
+    android:textSize="12sp"
+    android:textColor="@android:color/white"
+    android:background="@drawable/floating_button_background"
+    android:padding="8dp"
+    android:gravity="center"
+    android:clickable="true"
+    android:focusable="true" /> 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
     <string name="enable_wake_word">ENABLE WAKE WORD</string>
     <string name="wake_word_engine">Wake Word Engine</string>
     <string name="stt_engine">STT Engine</string>
-    <string name="porcupine_engine">Porcupine Engine (Recommended)</string>
+    <string name="porcupine_engine">If there is too much demand, our wake word service might be down, in that case we will add button at the bottom left and you can use it to activate panda</string>
     <string name="select_wake_word_engine">Select Wake Word Engine</string>
     <string name="wake_word_enabled">Wake Word enabled with %s</string>
     <string name="wake_word_disabled">Disable Wake Word</string>


### PR DESCRIPTION
- Remove STTfallback implementation completely 
- Add FloatingPandaButtonService that shows a floating button when Porcupine API fails 
- Position button in bottom-right corner with compact size 
- Update EnhancedWakeWordService to trigger floating button on API failure 
- Remove STT engine options from settings UI 
- Update user messages to reflect new wake word behavior 
- Fix service lifecycle issues by making FloatingPandaButtonService a regular service