### PR TITLE
:cloud_with_snow: Now the request goes thru a cloud function.  

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.blurr.voice"
         minSdk = 24
         targetSdk = 35
-        versionCode = 10
-        versionName = "1.0.10" +
+        versionCode = 11
+        versionName = "1.0.11" +
                 ""
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -68,6 +68,13 @@ android {
             val googlecloudGatewayURL = localProperties.getProperty("GCLOUD_GATEWAY_URL") ?: ""
             buildConfigField("String", "GCLOUD_GATEWAY_URL", "\"$googlecloudGatewayURL\"")
 
+            val googlecloudProxyURL = localProperties.getProperty("GCLOUD_PROXY_URL") ?: ""
+            val googlecloudProxyURLKey = localProperties.getProperty("GCLOUD_PROXY_URL_KEY") ?: ""
+
+            // Add fields to BuildConfig for the proxy
+            buildConfigField("String", "GCLOUD_PROXY_URL", "\"$googlecloudProxyURL\"")
+            buildConfigField("String", "GCLOUD_PROXY_URL_KEY", "\"$googlecloudProxyURLKey\"")
+
         }
         debug {
             // Also add it to the 'debug' block so it works when you run from Android Studio
@@ -93,6 +100,13 @@ android {
 
             val googlecloudGatewayURL = localProperties.getProperty("GCLOUD_GATEWAY_URL") ?: ""
             buildConfigField("String", "GCLOUD_GATEWAY_URL", "\"$googlecloudGatewayURL\"")
+            // Get properties from local.properties
+            val googlecloudProxyURL = localProperties.getProperty("GCLOUD_PROXY_URL") ?: ""
+            val googlecloudProxyURLKey = localProperties.getProperty("GCLOUD_PROXY_URL_KEY") ?: ""
+
+            // Add fields to BuildConfig for the proxy
+            buildConfigField("String", "GCLOUD_PROXY_URL", "\"$googlecloudProxyURL\"")
+            buildConfigField("String", "GCLOUD_PROXY_URL_KEY", "\"$googlecloudProxyURLKey\"")
 
         }
     }

--- a/app/src/main/assets/prompts/system_prompt.md
+++ b/app/src/main/assets/prompts/system_prompt.md
@@ -70,7 +70,6 @@ Examples:
 Note that:
 - Only elements with numeric indexes in [] are interactive
 - (stacked) indentation (with \t (tab)) is important and means that the element is a (XML) child of the element above (with a lower index)
-- Elements with \* are new elements that were added after the previous step.
 - Pure text elements without [] are not interactive.
   </android_state>
 

--- a/app/src/main/java/com/blurr/voice/v2/llm/GeminiAPI.kt
+++ b/app/src/main/java/com/blurr/voice/v2/llm/GeminiAPI.kt
@@ -168,7 +168,7 @@ class GeminiApi(
                 message.parts.forEach { part ->
                     if (part is TextPart) {
                         text(part.text)
-                        if(!part.text.startsWith("You are a tool-using AI agent designed")) {
+                        if(part.text.startsWith("<agent_history>") || part.text.startsWith("Memory:")) {
                             Log.d("GEMINIAPITEMP_INPUT", part.text)
                         }
                     }

--- a/app/src/main/java/com/blurr/voice/v2/llm/GeminiAPI.kt
+++ b/app/src/main/java/com/blurr/voice/v2/llm/GeminiAPI.kt
@@ -64,35 +64,6 @@ class GeminiApi(
     // Cache for GenerativeModel instances to avoid repeated initializations.
     private val modelCache = ConcurrentHashMap<String, GenerativeModel>()
 
-    /**
-     * KDoc comment to strongly advise developers to keep this schema synchronized
-     * with the AgentOutput data class to prevent runtime errors.
-     *
-     * IMPORTANT: This schema MUST be kept in sync with the [AgentOutput] data class.
-     * Any changes to [AgentOutput] must be reflected here.
-     */
-//    private val agentOutputSchema = Schema.obj(
-//        name = "agentOutput",
-//        description = "The structured output from the agent.",
-//        Schema.str("thinking", "The agent's inner monologue and reasoning."),
-//        Schema.str("evaluationPreviousGoal", "The agent's evaluation of the previous step's outcome."),
-//        Schema.str("memory", "The agent's short-term memory for the next step."),
-//        Schema.str("nextGoal", "The agent's immediate goal for the current step."),
-//        Schema.arr(
-//            name = "action",
-//            description = "A list of actions to be executed.",
-//            items = Schema.obj(
-//                "actionSpec",
-//                "A single action specification.",
-//                Schema.enum("name", "The name of the action to execute.", ForeignKey.Action.entries.map { it.name }),
-//                Schema.obj(
-//                    "parameters", "A map of parameter names to their values for the action."
-//                    // NOTE: We define `parameters` as a generic object. The LLM will populate it.
-//                    // This is more flexible than defining every parameter for every action.
-//                )
-//            )
-//        )
-//    )
 
 
     private val jsonGenerationConfig = GenerationConfig.builder().apply {
@@ -194,42 +165,6 @@ class GeminiApi(
         val reason = response.promptFeedback?.blockReason?.name ?: "UNKNOWN"
         throw ContentBlockedException("Blocked or empty response from API. Reason: $reason")
     }
-
-    /**
-     * Performs the actual API call to the Gemini model.
-     *
-     * @param messages The list of [GeminiMessage] objects.
-     * @return The response text from the model as a String.
-     * @throws ServerException for API-level errors (e.g., invalid key, rate limits).
-     * @throws ContentBlockedException if the response was blocked for safety reasons.
-     * @throws Exception for other network or unexpected errors.
-     */
-//    private suspend fun performApiCall(messages: List<GeminiMessage>): String {
-//        val apiKey = apiKeyManager.getNextKey()
-//
-//        // Use cached model instance or create a new one if it doesn't exist for the given key.
-//        val generativeModel = modelCache.getOrPut(apiKey) {
-//            Log.d(TAG, "Creating new GenerativeModel instance for key ending in ...${apiKey.takeLast(4)}")
-//            GenerativeModel(
-//                modelName = modelName,
-//                apiKey = apiKey,
-//                generationConfig = jsonGenerationConfig,
-//                requestOptions = requestOptions
-//            )
-//        }
-//
-//        val history = convertToSdkHistory(messages)
-//        val response = generativeModel.generateContent(*history.toTypedArray())
-//
-//        response.text?.let {
-//            Log.d(TAG, "Successfully received response from model.")
-//            return it
-//        }
-//
-//        // Handle cases where the response is empty or blocked.
-//        val reason = response.promptFeedback?.blockReason?.name ?: "UNKNOWN"
-//        throw ContentBlockedException("Blocked or empty response from API. Reason: $reason")
-//    }
 
     /**
      * Converts the internal `List<GeminiMessage>` to the `List<Content>` required by the Google AI SDK.

--- a/app/src/main/java/com/blurr/voice/v2/perception/SemanticParser.kt
+++ b/app/src/main/java/com/blurr/voice/v2/perception/SemanticParser.kt
@@ -286,7 +286,7 @@ class SemanticParser {
             return node.children
         }
         // 2. Decide what to do with the current node.
-        return if (node.isSemanticallyImportant() || node.children.isNotEmpty()) {
+        return if (node.isSemanticallyImportant() || node.isInteractive() || node.children.isNotEmpty()) {
             // Keep this node. Its (potentially promoted) children are already attached.
             listOf(node)
         } else {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,11 +1,11 @@
 <resources>
-    <string name="app_name">blurr</string>
+    <string name="app_name">panda</string>
     <string name="input_the_task">Input the Task</string>
     <string name="perform_task">Perform Task</string>
     <string name="content_filtering">Content Filtering</string>
     <string name="write_things_you_want_to_avoid">Write Things you want to avoid</string>
-    <string name="accessibility_service_label">Blurr Screen Agent Service</string>
-    <string name="accessibility_service_description">This service allows the app to perform taps and take screenshots for automation.</string>
+    <string name="accessibility_service_label">Panda Accessibility Service</string>
+    <string name="accessibility_service_description">To enable "Panda", our digital assistant, this service allows the app to listen for commands and perform actions like tapping and swiping. This is essential for controlling your phone with your voice.</string>
     <string name="view_source_code_on_github">⭐ Star us on Github</string>
     <string name="hello_sir">Hey, Panda Here</string>
     <string name="assistant_at_nyour_command">Assistant at\nYour Command</string>


### PR DESCRIPTION
I know this is anti-privacy, but this is the fastest way to implement key request distribution. 

This is the how the cloud function looks like:
```python
import os
import json
import functions_framework
import google.generativeai as genai
from google.cloud import secretmanager

# --- Initialize Clients and Configuration ---
# These are initialized once per function instance for efficiency.
secret_manager_client = secretmanager.SecretManagerServiceClient()

# --- In-memory cache for API keys and rotation index ---
# These global variables will persist between invocations on the same function instance.
CACHED_KEYS: list[str] | None = None
KEY_INDEX = 0

def _get_api_keys() -> list[str]:
    """
    Fetches the comma-separated list of API keys from Secret Manager.
    Caches the keys in a global variable to avoid repeated calls.
    """
    global CACHED_KEYS
    if CACHED_KEYS is not None:
        print("Using cached API keys.")
        return CACHED_KEYS

    if not PROJECT_ID or not SECRET_NAME:
        raise ValueError("GCP_PROJECT_ID and GEMINI_API_KEYS_SECRET env vars must be set.")

    print(f"Fetching secret '{SECRET_NAME}' for the first time.")
    secret_path = f"projects/{PROJECT_ID}/secrets/{SECRET_NAME}/versions/latest"
    
    try:
        response = secret_manager_client.access_secret_version(request={"name": secret_path})
        payload = response.payload.data.decode("UTF-8")
        keys = [key.strip() for key in payload.split(',') if key.strip()]
        
        if not keys:
            raise ValueError("Secret payload is empty or contains no valid keys.")
            
        CACHED_KEYS = keys
        print(f"Successfully fetched and cached {len(CACHED_KEYS)} API keys.")
        return CACHED_KEYS
    except Exception as e:
        print(f"FATAL: Failed to access secret version: {e}")
        # Return an empty list to prevent further errors, but log the failure.
        return []

def _get_next_key() -> str:
    """
    Retrieves the next API key from the cached list in a round-robin fashion.
    """
    global KEY_INDEX
    keys = _get_api_keys()
    if not keys:
        raise ConnectionError("API key list is empty. Check Secret Manager configuration.")

    key = keys[KEY_INDEX]
    KEY_INDEX = (KEY_INDEX + 1) % len(keys) # Rotate index for the next invocation
    
    # The log shows the key index that was *just used*.
    print(f"Using API key at index {(KEY_INDEX - 1 + len(keys)) % len(keys)}.")
    return key

@functions_framework.http
def gemini_proxy(request):
    """
    A secure HTTP proxy for the Gemini API. It handles key rotation internally.
    """
    # --- Set CORS headers for preflight requests and all responses ---
    headers = {
        'Access-Control-Allow-Origin': '*',  # Or specify your app's domain for production
        'Access-Control-Allow-Methods': 'POST, OPTIONS',
        'Access-Control-Allow-Headers': 'Content-Type',
    }

    if request.method == 'OPTIONS':
        return ('', 204, headers)

    if request.method != 'POST':
        return ('Method Not Allowed', 405, headers)

    try:
        if not PROXY_AUTH_KEY:
            # If the auth key isn't configured on the server, fail securely.
            print("FATAL: PROXY_AUTH_KEY environment variable not set.")
            return ({'error': 'Service is not configured correctly.'}, 500, headers)

        client_key = request.headers.get('X-API-Key')
        if not client_key or client_key != PROXY_AUTH_KEY:
            print("Authentication failed: Invalid or missing X-API-Key header.")
            return ({'error': 'Unauthorized'}, 401, headers) # Use 401 for unauthorized access
        
        print("Authentication successful.")
        # --- Input Validation ---
        request_json = request.get_json(silent=True)
        if not request_json or 'messages' not in request_json:
            return ({'error': 'Invalid request: JSON body with "messages" array is required.'}, 400, headers)

        messages = request_json['messages']
        model_name = request_json.get('modelName', 'gemini-1.5-flash-latest') # Default model

        # --- Core Logic ---
        api_key = _get_next_key()
        genai.configure(api_key=api_key)

        model = genai.GenerativeModel(
            model_name=model_name,
            generation_config={"response_mime_type": "application/json"}
        )

        # The Gemini Python SDK expects the history and the last prompt separately for `start_chat`.
        history = messages[:-1] if len(messages) > 1 else []
        last_prompt = messages[-1]['parts'][0]['text'] if messages else ""

        if not last_prompt:
             return ({'error': 'Invalid request: Last message part cannot be empty.'}, 400, headers)
        
        print(f"Calling Gemini model '{model_name}'...")
        chat = model.start_chat(history=history)
        response = chat.send_message(last_prompt)

        # The response text is a JSON string, so we parse it before returning.
        response_json = json.loads(response.text)
        print("Successfully received and parsed response from Gemini.")

        return (response_json, 200, headers)

    except Exception as e:
        print(f"An error occurred in gemini_proxy: {e}")
        return ({'error': 'An internal server error occurred.'}, 500, headers)
```