### PR TITLE
Fix: Keyboard hides instruction EditText in CreateTriggerActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,7 +73,7 @@
         </activity>
 
         <activity android:name=".triggers.ui.TriggersActivity" android:exported="false" android:label="Triggers" android:theme="@style/Theme.Blurr" />
-        <activity android:name=".triggers.ui.CreateTriggerActivity" android:exported="false" android:label="Create Trigger" android:theme="@style/Theme.Blurr" />
+        <activity android:name=".triggers.ui.CreateTriggerActivity" android:exported="false" android:label="Create Trigger" android:theme="@style/Theme.Blurr" android:windowSoftInputMode="adjustResize" />
         <activity android:name=".triggers.ui.ChooseTriggerTypeActivity" android:exported="false" android:label="Choose Trigger Type" android:theme="@style/Theme.Blurr" />
 
 

--- a/app/src/main/java/com/blurr/voice/triggers/ui/CreateTriggerActivity.kt
+++ b/app/src/main/java/com/blurr/voice/triggers/ui/CreateTriggerActivity.kt
@@ -52,16 +52,16 @@ class CreateTriggerActivity : AppCompatActivity() {
         timePicker = findViewById(R.id.timePicker)
         appsRecyclerView = findViewById(R.id.appsRecyclerView)
         dayOfWeekChipGroup = findViewById(R.id.dayOfWeekChipGroup)
-        scrollView = findViewById(R.id.scrollView)
+//        scrollView = findViewById(R.id.scrollView)
 
-        instructionEditText.setOnFocusChangeListener { view, hasFocus ->
-            if (hasFocus) {
-                // Delay scrolling until the keyboard is likely to be visible
-                view.postDelayed({
-                    scrollView.smoothScrollTo(0, view.bottom)
-                }, 200)
-            }
-        }
+//        instructionEditText.setOnFocusChangeListener { view, hasFocus ->
+//            if (hasFocus) {
+//                // Delay scrolling until the keyboard is likely to be visible
+//                view.postDelayed({
+//                    scrollView.smoothScrollTo(0, view.bottom)
+//                }, 200)
+//            }
+//        }
 
         // Set default checked state for all day chips
         for (i in 0 until dayOfWeekChipGroup.childCount) {

--- a/app/src/main/java/com/blurr/voice/triggers/ui/CreateTriggerActivity.kt
+++ b/app/src/main/java/com/blurr/voice/triggers/ui/CreateTriggerActivity.kt
@@ -7,6 +7,7 @@ import android.widget.Button
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.RadioGroup
+import android.widget.ScrollView
 import android.widget.TimePicker
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -31,6 +32,7 @@ class CreateTriggerActivity : AppCompatActivity() {
     private lateinit var appsRecyclerView: RecyclerView
     private lateinit var dayOfWeekChipGroup: com.google.android.material.chip.ChipGroup
     private lateinit var appAdapter: AppAdapter
+    private lateinit var scrollView: ScrollView
 
     private var selectedTriggerType = TriggerType.SCHEDULED_TIME
     private var selectedApp: AppInfo? = null
@@ -50,6 +52,16 @@ class CreateTriggerActivity : AppCompatActivity() {
         timePicker = findViewById(R.id.timePicker)
         appsRecyclerView = findViewById(R.id.appsRecyclerView)
         dayOfWeekChipGroup = findViewById(R.id.dayOfWeekChipGroup)
+        scrollView = findViewById(R.id.scrollView)
+
+        instructionEditText.setOnFocusChangeListener { view, hasFocus ->
+            if (hasFocus) {
+                // Delay scrolling until the keyboard is likely to be visible
+                view.postDelayed({
+                    scrollView.smoothScrollTo(0, view.bottom)
+                }, 200)
+            }
+        }
 
         // Set default checked state for all day chips
         for (i in 0 until dayOfWeekChipGroup.childCount) {

--- a/app/src/main/res/layout/activity_create_trigger.xml
+++ b/app/src/main/res/layout/activity_create_trigger.xml
@@ -44,6 +44,24 @@
                     android:layout_height="wrap_content"
                     android:theme="@style/AppTheme.NumberPicker"
                     android:timePickerMode="spinner" />
+                <TextView
+                    style="@style/PermissionHeading"
+                    android:text="Task Instruction" />
+
+                <EditText
+                    android:id="@+id/instructionEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/edit_text_border"
+                    android:hint="e.g., 'Read the notification'"
+                    android:inputType="textMultiLine"
+                    android:minLines="2"
+                    android:maxLines="5"
+                    android:scrollbars="vertical"
+                    android:gravity="top"
+                    android:padding="12dp"
+                    android:textColor="@color/white"
+                    android:textColorHint="#8A8A8E" />
 
                 <TextView
                     style="@style/PermissionHeading"
@@ -85,24 +103,6 @@
                     tools:listitem="@layout/item_app" />
             </LinearLayout>
 
-            <TextView
-                style="@style/PermissionHeading"
-                android:text="Task Instruction" />
-
-            <EditText
-                android:id="@+id/instructionEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@drawable/edit_text_border"
-                android:hint="e.g., 'Read the notification'"
-                android:inputType="textMultiLine"
-                android:minLines="2"
-                android:maxLines="5"
-                android:scrollbars="vertical"
-                android:gravity="top"
-                android:padding="12dp"
-                android:textColor="@color/white"
-                android:textColorHint="#8A8A8E" />
 
             <Button
                 android:id="@+id/saveTriggerButton"

--- a/app/src/main/res/layout/activity_create_trigger.xml
+++ b/app/src/main/res/layout/activity_create_trigger.xml
@@ -16,6 +16,7 @@
         app:titleTextColor="@color/white" />
 
     <ScrollView
+        android:id="@+id/scrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@id/toolbar"


### PR DESCRIPTION
The soft keyboard was covering the instruction EditText when it was focused, preventing the user from seeing what they were typing.

This was fixed by:
1.  Setting `android:windowSoftInputMode="adjustResize"` for `CreateTriggerActivity` in the manifest.
2.  Ensuring the layout is wrapped in a `ScrollView`.
3.  Adding an `OnFocusChangeListener` to the `EditText` that programmatically scrolls the `ScrollView` to make the input field visible when it gains focus. This provides a more robust solution than relying on `adjustResize` alone.