### PR TITLE
feat: Centralize task deduction in AgentService

### DIFF
--- a/app/src/main/java/com/blurr/voice/ConversationalAgentService.kt
+++ b/app/src/main/java/com/blurr/voice/ConversationalAgentService.kt
@@ -541,7 +541,6 @@ class ConversationalAgentService : Service() {
                         if(freemiumManager.canPerformTask()){
                             Log.d("ConvAgent", "Allowance check passed. Proceeding with task.")
 
-                            freemiumManager.decrementTaskCount()
                             if (clarificationAttempts < maxClarificationAttempts) {
                                 val (needsClarification, questions) = checkIfClarificationNeeded(
                                     decision.instruction


### PR DESCRIPTION
This commit refactors the task deduction logic to be centralized within the `AgentService`. Previously, task deductions for voice-initiated tasks were handled in `ConversationalAgentService`, while other triggers had no deduction logic. This led to inconsistent behavior and a double-deduction bug when the logic was added to `TriggerReceiver`.

This change centralizes all task deductions within `AgentService`, ensuring that every task, regardless of its trigger source (voice, schedule, notification), is correctly deducted from the user's free task allowance. This eliminates the double-deduction bug and improves the overall architecture and maintainability of the codebase.