### PR TITLE
Feat: Add Advanced Settings for Gemini API Keys

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -155,6 +155,7 @@ dependencies {
     implementation("androidx.recyclerview:recyclerview:1.3.2")
     implementation("com.revenuecat.purchases:purchases:9.7.0")
     implementation("com.revenuecat.purchases:purchases-ui:9.7.0")
+    implementation("androidx.security:security-crypto:1.0.0")
 }
 
 // Task to increment version for release builds

--- a/app/src/main/java/com/blurr/voice/AdvancedSettingsActivity.kt
+++ b/app/src/main/java/com/blurr/voice/AdvancedSettingsActivity.kt
@@ -1,0 +1,81 @@
+package com.blurr.voice
+
+import android.os.Bundle
+import android.view.View
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.SwitchCompat
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.blurr.voice.utilities.GeminiKeyManager
+
+class AdvancedSettingsActivity : AppCompatActivity() {
+
+    private lateinit var switchUseCustomKeys: SwitchCompat
+    private lateinit var textWarning: TextView
+    private lateinit var editGeminiKey: EditText
+    private lateinit var buttonAddKey: Button
+    private lateinit var recyclerViewKeys: RecyclerView
+    private lateinit var geminiKeyManager: GeminiKeyManager
+    private lateinit var keyAdapter: GeminiKeyAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_advanced_settings)
+
+        switchUseCustomKeys = findViewById(R.id.switchUseCustomKeys)
+        textWarning = findViewById(R.id.textWarning)
+        editGeminiKey = findViewById(R.id.editGeminiKey)
+        buttonAddKey = findViewById(R.id.buttonAddKey)
+        recyclerViewKeys = findViewById(R.id.recyclerViewKeys)
+        geminiKeyManager = GeminiKeyManager(this)
+
+        setupRecyclerView()
+        setupListeners()
+
+        // Set initial state of the UI based on saved preference
+        val useCustomKeys = geminiKeyManager.useCustomKeys()
+        switchUseCustomKeys.isChecked = useCustomKeys
+        updateUiVisibility(useCustomKeys)
+    }
+
+    private fun setupListeners() {
+        switchUseCustomKeys.setOnCheckedChangeListener { _, isChecked ->
+            geminiKeyManager.setUseCustomKeys(isChecked)
+            updateUiVisibility(isChecked)
+        }
+
+        buttonAddKey.setOnClickListener {
+            val key = editGeminiKey.text.toString().trim()
+            if (key.isNotEmpty()) {
+                geminiKeyManager.addKey(key)
+                editGeminiKey.text.clear()
+                updateKeyList()
+            }
+        }
+    }
+
+    private fun setupRecyclerView() {
+        val keys = geminiKeyManager.getKeys().toMutableList()
+        keyAdapter = GeminiKeyAdapter(keys) { key ->
+            geminiKeyManager.deleteKey(key)
+            updateKeyList()
+        }
+        recyclerViewKeys.adapter = keyAdapter
+        recyclerViewKeys.layoutManager = LinearLayoutManager(this)
+    }
+
+    private fun updateKeyList() {
+        keyAdapter.updateKeys(geminiKeyManager.getKeys())
+    }
+
+    private fun updateUiVisibility(isCustomKeyMode: Boolean) {
+        val visibility = if (isCustomKeyMode) View.VISIBLE else View.GONE
+        textWarning.visibility = visibility
+        editGeminiKey.visibility = visibility
+        buttonAddKey.visibility = visibility
+        recyclerViewKeys.visibility = visibility
+    }
+}

--- a/app/src/main/java/com/blurr/voice/GeminiKeyAdapter.kt
+++ b/app/src/main/java/com/blurr/voice/GeminiKeyAdapter.kt
@@ -1,0 +1,45 @@
+package com.blurr.voice
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+class GeminiKeyAdapter(
+    private var keys: MutableList<String>,
+    private val onDelete: (String) -> Unit
+) : RecyclerView.Adapter<GeminiKeyAdapter.KeyViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): KeyViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_gemini_key, parent, false)
+        return KeyViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: KeyViewHolder, position: Int) {
+        val key = keys[position]
+        holder.bind(key, onDelete)
+    }
+
+    override fun getItemCount(): Int = keys.size
+
+    fun updateKeys(newKeys: List<String>) {
+        keys.clear()
+        keys.addAll(newKeys)
+        notifyDataSetChanged()
+    }
+
+    class KeyViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val textGeminiKey: TextView = itemView.findViewById(R.id.textGeminiKey)
+        private val buttonDeleteKey: Button = itemView.findViewById(R.id.buttonDeleteKey)
+
+        fun bind(key: String, onDelete: (String) -> Unit) {
+            textGeminiKey.text = key
+            buttonDeleteKey.setOnClickListener {
+                onDelete(key)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/blurr/voice/SettingsActivity.kt
+++ b/app/src/main/java/com/blurr/voice/SettingsActivity.kt
@@ -45,6 +45,7 @@ class SettingsActivity : AppCompatActivity() {
     private lateinit var wakeWordButton: TextView // NEW: Declare wake word button
     private lateinit var wakeWordManager: WakeWordManager // NEW: Wake word manager
     private lateinit var requestPermissionLauncher: ActivityResultLauncher<String> // NEW: Permission launcher
+    private lateinit var advancedSettingsButton: TextView
 
 
     private lateinit var sc: SpeechCoordinator
@@ -109,6 +110,7 @@ class SettingsActivity : AppCompatActivity() {
         editUserName = findViewById(R.id.editUserName)
         editUserEmail = findViewById(R.id.editUserEmail)
         textGetPicovoiceKeyLink = findViewById(R.id.textGetPicovoiceKeyLink) // NEW: Initialize the TextView
+        advancedSettingsButton = findViewById(R.id.advancedSettingsButton)
 
 
         setupClickListeners()
@@ -173,6 +175,11 @@ class SettingsActivity : AppCompatActivity() {
                 Toast.makeText(this, "Could not open link. No browser found.", Toast.LENGTH_SHORT).show()
                 Log.e("SettingsActivity", "Failed to open Picovoice link", e)
             }
+        }
+
+        advancedSettingsButton.setOnClickListener {
+            val intent = Intent(this, AdvancedSettingsActivity::class.java)
+            startActivity(intent)
         }
     }
 

--- a/app/src/main/java/com/blurr/voice/data/MemoryManager.kt
+++ b/app/src/main/java/com/blurr/voice/data/MemoryManager.kt
@@ -39,6 +39,7 @@ class MemoryManager(private val context: Context) {
                 
                 // Generate embedding for the text
                 val embedding = EmbeddingService.generateEmbedding(
+                    context = context,
                     text = originalText,
                     taskType = "RETRIEVAL_DOCUMENT"
                 )
@@ -94,6 +95,7 @@ class MemoryManager(private val context: Context) {
                 
                 // Generate embedding for the query
                 val queryEmbedding = EmbeddingService.generateEmbedding(
+                    context = context,
                     text = query,
                     taskType = "RETRIEVAL_QUERY"
                 )
@@ -204,6 +206,7 @@ class MemoryManager(private val context: Context) {
             try {
                 // Generate embedding for the query text
                 val queryEmbedding = EmbeddingService.generateEmbedding(
+                    context = context,
                     text = text,
                     taskType = "RETRIEVAL_QUERY"
                 )
@@ -290,4 +293,4 @@ class MemoryManager(private val context: Context) {
             }
         }
     }
-} 
+}

--- a/app/src/main/java/com/blurr/voice/utilities/GeminiKeyManager.kt
+++ b/app/src/main/java/com/blurr/voice/utilities/GeminiKeyManager.kt
@@ -1,0 +1,65 @@
+package com.blurr.voice.utilities
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+
+class GeminiKeyManager(context: Context) {
+
+    private val prefs: SharedPreferences
+
+    init {
+        val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+        prefs = EncryptedSharedPreferences.create(
+            PREFS_NAME,
+            masterKeyAlias,
+            context,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    fun addKey(key: String) {
+        val keys = getKeys().toMutableSet()
+        keys.add(key)
+        prefs.edit().putStringSet(KEY_GEMINI_KEYS, keys).apply()
+    }
+
+    fun getKeys(): List<String> {
+        return prefs.getStringSet(KEY_GEMINI_KEYS, emptySet())?.toList() ?: emptyList()
+    }
+
+    fun deleteKey(key: String) {
+        val keys = getKeys().toMutableSet()
+        if (keys.remove(key)) {
+            prefs.edit().putStringSet(KEY_GEMINI_KEYS, keys).apply()
+        }
+    }
+
+    fun setUseCustomKeys(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_USE_CUSTOM_KEYS, enabled).apply()
+    }
+
+    fun useCustomKeys(): Boolean {
+        return prefs.getBoolean(KEY_USE_CUSTOM_KEYS, false)
+    }
+
+    fun getNextKey(): String? {
+        val keys = getKeys()
+        if (keys.isEmpty()) {
+            return null
+        }
+        val lastUsedIndex = prefs.getInt(KEY_LAST_USED_INDEX, -1)
+        val nextIndex = (lastUsedIndex + 1) % keys.size
+        prefs.edit().putInt(KEY_LAST_USED_INDEX, nextIndex).apply()
+        return keys[nextIndex]
+    }
+
+    companion object {
+        private const val PREFS_NAME = "GeminiKeyPrefs"
+        private const val KEY_GEMINI_KEYS = "gemini_keys"
+        private const val KEY_USE_CUSTOM_KEYS = "use_custom_keys"
+        private const val KEY_LAST_USED_INDEX = "last_used_index"
+    }
+}

--- a/app/src/main/res/layout/activity_advanced_settings.xml
+++ b/app/src/main/res/layout/activity_advanced_settings.xml
@@ -1,0 +1,48 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    tools:context=".AdvancedSettingsActivity">
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/switchUseCustomKeys"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Use Custom Gemini Keys"
+        android:textSize="18sp" />
+
+    <TextView
+        android:id="@+id/textWarning"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/switchUseCustomKeys"
+        android:layout_marginTop="8dp"
+        android:text="Warning: The app may not work properly with just 1 free API key. Add at least 3 free keys. You may be charged for usage with paid keys."
+        android:textColor="@android:color/holo_red_light"
+        android:visibility="gone" />
+
+    <EditText
+        android:id="@+id/editGeminiKey"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/textWarning"
+        android:layout_marginTop="16dp"
+        android:hint="Enter Gemini API Key" />
+
+    <Button
+        android:id="@+id/buttonAddKey"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/editGeminiKey"
+        android:layout_alignParentEnd="true"
+        android:text="Add" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewKeys"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/buttonAddKey"
+        android:layout_marginTop="16dp" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -291,6 +291,29 @@
             android:textSize="16sp"
             android:textStyle="bold" />
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:background="@drawable/rounded_background"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/advancedSettingsButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/rounded_button"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center"
+                android:padding="12dp"
+                android:text="Advanced Settings"
+                android:textColor="@android:color/white"
+                android:textSize="16sp" />
+
+        </LinearLayout>
+
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/item_gemini_key.xml
+++ b/app/src/main/res/layout/item_gemini_key.xml
@@ -1,0 +1,21 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/textGeminiKey"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_toStartOf="@id/buttonDeleteKey"
+        android:textSize="16sp" />
+
+    <Button
+        android:id="@+id/buttonDeleteKey"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:text="Delete" />
+
+</RelativeLayout>


### PR DESCRIPTION
This commit introduces a new "Advanced Settings" page that allows users to add and manage their own Gemini API keys.

Key features include:
- A new screen to add, view, and delete multiple Gemini API keys.
- Secure storage of API keys using EncryptedSharedPreferences.
- A toggle switch to enable or disable the use of custom keys.
- Updated API call logic to use user-provided keys for direct API calls when enabled, bypassing the default proxy.
- A warning message in the UI to inform users about potential costs and key requirements.